### PR TITLE
CDH 5.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,9 @@ uniformDependencySettings
 uniformThriftSettings
 strictDependencySettings
 
+// TODO: Move this into UniformDependencyPlugin public resolver list
+resolvers += "Twitter Maven HTTPS" at "https://maven.twttr.com"
+
 val omnitoolVersion    = "1.15.0-20180124002420-8583973-cdh-513"
 val thermometerVersion = "1.6.0-20180124000127-aec09bd-cdh-513"
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ uniformDependencySettings
 uniformThriftSettings
 strictDependencySettings
 
-val omnitoolVersion    = "1.14.9-20170710003444-8f25fcd"
-val thermometerVersion = "1.5.10-20170501023059-67accaf"
+val omnitoolVersion    = "1.15.0-20180124002420-8583973-cdh-513"
+val thermometerVersion = "1.6.0-20180124000127-aec09bd-cdh-513"
 
 libraryDependencies :=
   depend.hadoopClasspath ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ resolvers ++= Seq(
   "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
 )
 
-val uniformVersion = "1.15.1-20170426071414-6d891a6"
+val uniformVersion = "1.16.0-20180123221516-1f65521-cdh-513"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 

--- a/src/test/scala/au/com/cba/omnia/beeswax/HiveSpec.scala
+++ b/src/test/scala/au/com/cba/omnia/beeswax/HiveSpec.scala
@@ -218,7 +218,7 @@ Hive operations:
       dbs <- Hive.query("SHOW DATABASES")
     } yield dbs
 
-    x must beValue(List("test"))
+    x must beValue(List("default", "test"))
   }
 
   def queries = {
@@ -227,7 +227,7 @@ Hive operations:
       res <- Hive.queries(List("SHOW DATABASES", "SHOW TABLES IN test"))
     } yield res
 
-    x must beValue(List(List("test"), List("test2")))
+    x must beValue(List(List("default", "test"), List("test2")))
   }
 
   def queriesOrdered = {

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.1.15"
+version in ThisBuild := "0.2.0"
 
 localVersionSettings
 


### PR DESCRIPTION
This will be merged into a new release branch: *cdh-513*. CDH 5.13.1 is not yet productionised in Omnia and won't be for a few months.

Driven by [Uniform PR #103](https://github.com/CommBank/uniform/pull/103) .

Upgrades libraries to CDH 5.13.0, as per:
 - https://archive.cloudera.com/cdh5/cdh/5/hadoop/hadoop-project-dist/hadoop-common/dependency-analysis.html
 - https://www.cloudera.com/documentation/enterprise/release-notes/topics/cm_vd_cdh_package_tarball_513.html